### PR TITLE
feat: 관심사 정보 수정 service, controller 구현

### DIFF
--- a/src/main/java/com/codeit/monew/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/interest/controller/InterestController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.codeit.monew.interest.dto.InterestDto;
 import com.codeit.monew.interest.dto.InterestRegisterRequest;
+import com.codeit.monew.interest.dto.InterestUpdateRequest;
 import com.codeit.monew.interest.service.InterestService;
 
 import jakarta.validation.Valid;
@@ -45,6 +47,18 @@ public class InterestController {
 	){
 		interestService.deleteInterest(interestId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	/**
+	 * 관심사 정보 수정
+	 */
+	@PatchMapping("/{interestId}")
+	public ResponseEntity<InterestDto> updateInterest(
+		@PathVariable UUID interestId,
+		@Valid @RequestBody InterestUpdateRequest request
+	){
+		InterestDto updateInterest = interestService.updateInterest(interestId, request);
+		return ResponseEntity.ok(updateInterest);
 	}
 
 }

--- a/src/main/java/com/codeit/monew/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/interest/service/InterestService.java
@@ -1,9 +1,12 @@
 package com.codeit.monew.interest.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.text.similarity.JaroWinklerSimilarity;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,7 @@ import com.codeit.monew.interest.domain.Interest;
 import com.codeit.monew.interest.domain.InterestKeyword;
 import com.codeit.monew.interest.dto.InterestDto;
 import com.codeit.monew.interest.dto.InterestRegisterRequest;
+import com.codeit.monew.interest.dto.InterestUpdateRequest;
 import com.codeit.monew.interest.mapper.InterestMapper;
 import com.codeit.monew.interest.repository.InterestRepository;
 
@@ -59,12 +63,44 @@ public class InterestService {
 	 * 관심사 물리 삭제
 	 */
 	@Transactional
-	public void deleteInterest(UUID interestId){
-		if (!interestRepository.existsById(interestId)){
+	public void deleteInterest(UUID interestId) {
+		if (!interestRepository.existsById(interestId)) {
 			throw new NoSuchElementException("해당 id의 관심사를 찾을 수 없습니다");
 		}
 		interestRepository.deleteById(interestId);
 
+	}
+
+	/**
+	 * 관심사 정보 수정
+	 */
+	@Transactional
+	public InterestDto updateInterest(UUID interestId, InterestUpdateRequest request) {
+		Interest interest = interestRepository.findById(interestId).orElseThrow(
+			() -> new NoSuchElementException("해당 id의 관심사를 찾을 수 없습니다.")
+		);
+
+		Set<String> existingKeywordString = interest.getKeywords().stream()
+			.map(InterestKeyword::getKeyword)
+			.collect(Collectors.toSet());
+
+		Set<String> requestedKeywordString = new HashSet<>(request.keywords());
+
+		interest.getKeywords().removeIf(
+			keyword -> !requestedKeywordString.contains(keyword.getKeyword()));
+		interestRepository.flush();
+
+		requestedKeywordString.forEach(keywordString -> {
+			if (!existingKeywordString.contains(keywordString)){
+				InterestKeyword newKeyword = InterestKeyword.builder()
+					.keyword(keywordString)
+					.interest(interest)
+					.build();
+				interest.getKeywords().add(newKeyword);
+			}
+		});
+
+		return interestMapper.toDto(interest, false);
 	}
 
 	/**


### PR DESCRIPTION
## 🚀 Monew PR Template

### 🔗 Related Issue

---

### 🧩 Summary
- 관심사 정보 수정 구현

---

### 💡 Implementation Details
- InterestController: 관심사 정보 수정 엔드포인트 추가
- InterestService
- 관심사 정보 수정 시 db에 이미 있는 키워드와 새로 요청받은 키워드를 비교하여 기존에 있는 키워드가 요청값에 있으면 유지, 기존에 없는 키워드가 요청값에 있으면 db에 추가, db에는 있지만 요청받은 키워드에 없을 경우 삭제하는 로직으로 구현

---

### ✅ Checklist
- [ ] 관련된 Issue 번호를 `closes #번호` 형태로 연결했다.
- [x] 로컬 환경에서 정상적으로 동작을 확인했다.
- [x] 코드 리뷰 가이드를 준수했다.
- [ ] 테스트 코드 또는 로깅을 추가했다 (필요 시).
- [x] 문서/주석을 업데이트했다.

---

### 🧪 Test Results (선택)
<img width="1081" height="1037" alt="image" src="https://github.com/user-attachments/assets/881cd306-f27c-47f6-a323-c55959712048" />
<img width="968" height="383" alt="image" src="https://github.com/user-attachments/assets/614b11c2-26a7-4647-ab32-eb74ccc7a24f" />
> 기존에 있는 키워드인 "주식"의 경우 id값이 유지되는 것을 확인.
---

### 🗒️ 기타 참고 사항 (Optional)

